### PR TITLE
Make PE_ANGLE_RESOLUTION overrideable via environment variable

### DIFF
--- a/src/se/raddo/raddose3D/CrystalPolyhedron.java
+++ b/src/se/raddo/raddose3D/CrystalPolyhedron.java
@@ -136,7 +136,15 @@ public class CrystalPolyhedron extends Crystal {
    * The angle resolution is the number of tracks to send out the dose along per voxel.
    * This is 1*1 and is randomly chosen for each voxel
    */
-  private static final int   PE_ANGLE_RESOLUTION = 1;
+  private static final int   PE_ANGLE_RESOLUTION;
+  static {
+    String env = System.getenv("PE_ANGLE_RESOLUTION");
+    int val = 1;
+    if (env != null) {
+      try { val = Integer.parseInt(env); } catch (NumberFormatException ignored) { }
+    }
+    PE_ANGLE_RESOLUTION = val;
+  }
   private static final int   PE_ANGLE_RES_LIMIT = 100;
   
   private static final int   FL_ANGLE_RESOLUTION = 1;


### PR DESCRIPTION
CrystalPolyhedron uses this to calculate dose effects from photoelectrons. It samples PE_ANGLE_RESOLUTION² random tracks to calculate:
https://github.com/GarmanGroup/RADDOSE-3D/blob/78d29382145eaa26cfcdd66f2498a15f4d7ba670/src/se/raddo/raddose3D/CrystalPolyhedron.java#L2082

 By default this is hardcoded to one, but I've found it useful to up (at simulation time cost) for statistical comparisons, when comparing algorithm re-implementations.